### PR TITLE
updated readme to include instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Open-source, reusable dashboard template.
 
 First you are going to need to have an instance of [py-auth-api](https://github.com/onyxcode/py-auth-api) already setup and running.
 
+Next, you need to install sanic with:
+
+```bash
+pip3 install -r requirements.txt
+```
+
 ### Run
 
 Once you have that running you can simply start the dashboard with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # xDash
+
 Open-source, reusable dashboard template.
 
+## Usage
+
+First you are going to need to have an instance of [py-auth-api](https://github.com/onyxcode/py-auth-api) already setup and running.
+
+### Run
+
+Once you have that running you can simply start the dashboard with:
+
+```bash
+python3 run.py
+```


### PR DESCRIPTION
added instructions to the readme that says that you need to have py-auth-api running on your machine and then you can run python3 run.py